### PR TITLE
standard workflows for pipeline error fix

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -32,6 +32,12 @@ jobs:
           java-version: '21'
           cache: 'maven'
 
+      - name: Make Maven Wrapper executable
+        if: steps.check-pom.outputs.pom_exists == 'true'
+        run: |
+          cd services/api
+          chmod +x ./mvnw
+
       - name: Build & Test (API)
         if: steps.check-pom.outputs.pom_exists == 'true'
         run: |

--- a/.github/workflows/ci-app.yml
+++ b/.github/workflows/ci-app.yml
@@ -29,7 +29,7 @@ jobs:
         if: steps.check_pubspec.outputs.has_pubspec == 'true'
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.0'
+          flutter-version: '3.35.6' # FIX: Updated to match Dart SDK ^3.9.2 requirement
 
       - name: Pub get & Analyze & Test
         if: steps.check_pubspec.outputs.has_pubspec == 'true'
@@ -37,4 +37,11 @@ jobs:
         run: |
           flutter pub get
           flutter analyze
-          flutter test --coverage
+      - name: Run tests (if test directory exists)
+        run: |
+          cd apps/mobile
+          if [ -d "test" ]; then
+            flutter test --coverage
+          else
+            echo "No test directory found, skipping tests"
+          fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,9 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,10 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Updated workflow files so that their content is the same across all branches and `main` is finally updated. That way, claude code review will no longer throw an error when run.